### PR TITLE
Allow for private buckets

### DIFF
--- a/file/url/defaultloader/loader.go
+++ b/file/url/defaultloader/loader.go
@@ -21,6 +21,7 @@ func New() url.Loader {
 		s3url.NewLoader(s3url.Options{
 			AccessKey: os.Getenv("AWS_ACCESS_KEY_ID"),
 			SecretKey: os.Getenv("AWS_SECRET_ACCESS_KEY"),
+			Private:   os.Getenv("AWS_PRIVATE_BUCKET") == "true",
 		}),
 		urlutil.NewEmptySchemeLoader(file),
 	)

--- a/file/url/s3/loader.go
+++ b/file/url/s3/loader.go
@@ -66,5 +66,5 @@ func (f loader) LoadURL(source metalink.URL) (file.Reference, error) {
 		return nil, errors.Wrap(err, "Creating s3 client")
 	}
 
-	return NewReference(client, secure, parsed.Hostname(), split[1], split[2]), nil
+	return NewReference(client, secure, parsed.Hostname(), split[1], split[2], f.options.Private), nil
 }

--- a/file/url/s3/options.go
+++ b/file/url/s3/options.go
@@ -3,4 +3,5 @@ package s3
 type Options struct {
 	AccessKey string `json:"access_key" yaml:"access_key"`
 	SecretKey string `json:"secret_key" yaml:"secret_key"`
+	Private   bool   `json:"private" yaml:"private"`
 }

--- a/file/url/s3/reference.go
+++ b/file/url/s3/reference.go
@@ -12,22 +12,24 @@ import (
 )
 
 type Reference struct {
-	client   *minio.Client
-	endpoint string
-	bucket   string
-	object   string
-	secure   bool
+	client        *minio.Client
+	endpoint      string
+	bucket        string
+	object        string
+	secure        bool
+	privateBucket bool
 }
 
 var _ file.Reference = Reference{}
 
-func NewReference(client *minio.Client, secure bool, endpoint string, bucket string, object string) Reference {
+func NewReference(client *minio.Client, secure bool, endpoint string, bucket string, object string, privateBucket bool) Reference {
 	return Reference{
-		client:   client,
-		secure:   secure,
-		endpoint: endpoint,
-		bucket:   bucket,
-		object:   object,
+		client:        client,
+		secure:        secure,
+		endpoint:      endpoint,
+		bucket:        bucket,
+		object:        object,
+		privateBucket: privateBucket,
 	}
 }
 
@@ -54,6 +56,10 @@ func (o Reference) ReaderURI() string {
 
 	if !o.secure {
 		scheme = "http"
+	}
+
+	if o.privateBucket {
+		scheme = "s3"
 	}
 
 	return fmt.Sprintf("%s://%s/%s/%s", scheme, o.endpoint, o.bucket, o.object)


### PR DESCRIPTION
- Downloading from private buckets only works with the s3:// scheme
- This adds a "private" boolean option to make metalink generate an
s3:// URL as output

Co-authored-by: Max Petersen <mpetersen@pivotal.io>