### PR TITLE
Fix rebasing errors when git author is unset

### DIFF
--- a/repository/source/git/source.go
+++ b/repository/source/git/source.go
@@ -212,6 +212,7 @@ func (s Source) Put(name string, data io.Reader) error {
 				s.branch,
 			},
 			WorkingDir: s.clonedir,
+			Env:        commitEnv,
 		})
 		if err != nil {
 			return errors.Wrap(err, "rebasing")


### PR DESCRIPTION
Co-authored-by: Joshua Aresty <joshua.aresty@emc.com>